### PR TITLE
Fix filter retention in chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In order to load all the images you will have to scroll to the bottom of the pag
 
 - `retain-filters-on-chart-links.user.js`: retain filters on the chart links present in the page.
 
-For example if you navigate to the charts of the [top jazz albums](https://rateyourmusic.com/charts/top/album/all-time/g:jazz/) the chart links by decades (`2020s`, `2010s`, etc.) won't contain the genre tags. This userscript fixes that (only genres and artists filters are supported as of now).
+For example if you navigate to the charts of the [top jazz albums](https://rateyourmusic.com/charts/top/album/all-time/g:jazz/) the chart links by decades (`2020s`, `2010s`, etc.) won't contain the genre tags. This userscript fixes that and now retains all filters present in the URL.
 
 <a href="docs/userscript_genre_filter_retained.png"><img src="docs/userscript_genre_filter_retained.png" width="500"/></a>
 <a href="docs/userscript_artist_filter_retained.png"><img src="docs/userscript_artist_filter_retained.png" width="500"/></a>

--- a/retain-filters-on-chart-links.user.js
+++ b/retain-filters-on-chart-links.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RateYourMusic retain filters on chart links
 // @namespace    RateYourMusic scripts
-// @version      1.1
+// @version      1.2
 // @description  Retain filters on chart links.
 // @author       dbeley
 // @match        https://rateyourmusic.com/charts/*
@@ -20,10 +20,11 @@
             // Ensure the href ends with a `/` before appending
             href = href.endsWith('/') ? href : `${href}/`;
 
-            // Append all suffixes, ensuring no duplicate "/"
+            // Append all suffixes with a trailing `/`, ensuring they are not duplicated
             suffixes.forEach(suffix => {
-                if (!href.includes(suffix)) { // Avoid appending the same suffix multiple times
-                    href += suffix;
+                const segment = `${suffix}/`;
+                if (!href.includes(segment)) {
+                    href += segment;
                 }
             });
 
@@ -32,20 +33,10 @@
         });
     }
 
-    const url = window.location.href;
-    const genreMatch = url.match(/(g:[^/]+)/);
-    const artistMatch = url.match(/(a:[^/]+)/);
-    const locationMatch = url.match(/(l:[^/]+)/);
-    const descriptorMatch = url.match(/(l:[^/]+)/);
-    const languageMatch = url.match(/(l:[^/]+)/);
-
-    // Collect suffixes found in the URL
-    const suffixes = [];
-    if (genreMatch) suffixes.push(genreMatch[0]);
-    if (artistMatch) suffixes.push(artistMatch[0]);
-    if (locationMatch) suffixes.push(locationMatch[0]);
-    if (descriptorMatch) suffixes.push(descriptorMatch[0]);
-    if (languageMatch) suffixes.push(languageMatch[0]);
+    const url = new URL(window.location.href);
+    const suffixes = url.pathname
+        .split('/')
+        .filter(segment => segment.includes(':'));
 
     // Only proceed if we have any suffixes to append
     if (suffixes.length > 0) {


### PR DESCRIPTION
## Summary
- handle all filter segments when rewriting chart links
- ensure segments have slashes when appended
- update version to 1.2
- clarify README about filter support

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688be28fe6c8832ca6f3244a7a218b38